### PR TITLE
Path.owner() is unsupported on Windows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.5.0
   hooks:
   - id: check-ast
   - id: check-case-conflict
@@ -22,26 +22,26 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/PyCQA/bandit
-  rev: 1.7.5
+  rev: 1.7.8
   hooks:
   - id: bandit
     args: [-r, -ll, -c, pyproject.toml]
     additional_dependencies: ['bandit[toml]']
 
 - repo: https://github.com/psf/black
-  rev: 23.3.0
+  rev: 24.3.0
   hooks:
   - id: black
     args: [--safe, --quiet]
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.12.0
+  rev: 5.13.2
   hooks:
   - id: isort
     args: [--profile, black, --filter-files, -l, "120"]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.1.1
+  rev: v1.9.0
   hooks:
   - id: mypy
     args: [--no-strict-optional, --ignore-missing-imports]
@@ -55,7 +55,7 @@ repos:
     ]
 
 - repo: https://github.com/python-poetry/poetry
-  rev: 1.7.1
+  rev: 1.8.2
   hooks:
   - id: poetry-check
   - id: poetry-lock
@@ -85,7 +85,7 @@ repos:
     types: [file]
 
 - repo: https://github.com/pylint-dev/pylint
-  rev: v2.17.1
+  rev: v3.1.0
   hooks:
   - id: pylint
 
@@ -96,19 +96,19 @@ repos:
     args: [-d, --min=9, .]
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.3.1
+  rev: v3.15.1
   hooks:
   - id: pyupgrade
     args: [--py39-plus]
 
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.0.260
+  rev: v0.3.3
   hooks:
   - id: ruff
     args: [--fix]
 
 - repo: https://github.com/rstcheck/rstcheck
-  rev: v6.1.2
+  rev: v6.2.0
   hooks:
   - id: rstcheck
     args: [--report-level=warning, --ignore-directives, automodule]

--- a/hexabyte/__main__.py
+++ b/hexabyte/__main__.py
@@ -1,4 +1,5 @@
 """Haxabyte Package Main."""
+
 import argparse
 from importlib.metadata import version
 from pathlib import Path
@@ -37,9 +38,12 @@ def main():
             raise ValueError("Must specify at least one filename")
         if len(args.files) > MAX_FILE_COUNT:
             raise ValueError("Must not specify more than two filenames")
+        expanded_files = []
         for filename in args.files:
-            if not filename.exists():
-                raise FileNotFoundError(f"File not found: {filename}")
+            expanded_filename = filename.expanduser()
+            if not expanded_filename.exists():
+                raise FileNotFoundError(f"File not found: {expanded_filename}")
+            expanded_files.append(expanded_filename)
         context.config = Config.from_file(args.config)
         load_plugins()
         if len(args.files) > 1:
@@ -49,7 +53,7 @@ def main():
         else:
             file_mode = FileMode.NORMAL
         context.file_mode = file_mode
-        context.files = args.files
+        context.files = expanded_files
         app = HexabyteApp()
         app.run()
         context.config.save()

--- a/hexabyte/widgets/info_panel.py
+++ b/hexabyte/widgets/info_panel.py
@@ -1,7 +1,9 @@
 """Sidebar Info Panel."""
+
 import stat
 from hashlib import md5, sha1
 from pathlib import Path
+from sys import platform
 
 from textual.app import ComposeResult
 from textual.containers import Horizontal
@@ -54,8 +56,9 @@ class InfoPanel(SidebarVerticalPanel):
         yield InfoItem(name="filename")
         yield InfoItem(name="path")
         yield InfoItem(name="size")
-        yield InfoItem(name="owner")
-        yield InfoItem(name="group")
+        if platform != "win32":
+            yield InfoItem(name="owner")
+            yield InfoItem(name="group")
         yield InfoItem(name="permissions")
         yield InfoItem(name="md5")
         yield InfoItem(name="sha1")
@@ -87,14 +90,14 @@ class InfoPanel(SidebarVerticalPanel):
         else:
             kb_size = file_size // KB
             size_value.update(f"{kb_size:,} KB ({file_size:,} bytes)")
-        owner_value = self.query_one("#owner-value", Static)
-        owner_value.update(filepath.owner())
-
-        group_value = self.query_one("#group-value", Static)
-        group_value.update(filepath.group())
-
         perm_value = self.query_one("#permissions-value", Static)
         perm_value.update(stat.filemode(stats.st_mode))
+        if platform != "win32":
+            owner_value = self.query_one("#owner-value", Static)
+            owner_value.update(filepath.owner())
+
+            group_value = self.query_one("#group-value", Static)
+            group_value.update(filepath.group())
 
     def watch_editor(self) -> None:
         """React to changed editor."""

--- a/poetry.lock
+++ b/poetry.lock
@@ -878,13 +878,13 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "7.0.2"
+version = "7.1.0"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "importlib_metadata-7.0.2-py3-none-any.whl", hash = "sha256:f4bc4c0c070c490abf4ce96d715f68e95923320370efb66143df00199bb6c100"},
-    {file = "importlib_metadata-7.0.2.tar.gz", hash = "sha256:198f568f3230878cb1b44fbd7975f87906c22336dba2e4a7f05278c281fbd792"},
+    {file = "importlib_metadata-7.1.0-py3-none-any.whl", hash = "sha256:30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570"},
+    {file = "importlib_metadata-7.1.0.tar.gz", hash = "sha256:b78938b926ee8d5f020fc4772d487045805a55ddbad2ecf21c6d60938dc7fcd2"},
 ]
 
 [package.dependencies]
@@ -893,17 +893,17 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 perf = ["ipython"]
-testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1)"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1)"]
 
 [[package]]
 name = "importlib-resources"
-version = "6.3.1"
+version = "6.3.2"
 description = "Read resources from Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "importlib_resources-6.3.1-py3-none-any.whl", hash = "sha256:4811639ca7fa830abdb8e9ca0a104dc6ad13de691d9fe0d3173a71304f068159"},
-    {file = "importlib_resources-6.3.1.tar.gz", hash = "sha256:29a3d16556e330c3c8fb8202118c5ff41241cc34cbfb25989bbad226d99b7995"},
+    {file = "importlib_resources-6.3.2-py3-none-any.whl", hash = "sha256:f41f4098b16cd140a97d256137cfd943d958219007990b2afb00439fc623f580"},
+    {file = "importlib_resources-6.3.2.tar.gz", hash = "sha256:963eb79649252b0160c1afcfe5a1d3fe3ad66edd0a8b114beacffb70c0674223"},
 ]
 
 [package.dependencies]
@@ -1626,13 +1626,13 @@ pygments = ">2.12.0"
 
 [[package]]
 name = "mkdocs-material"
-version = "9.5.13"
+version = "9.5.14"
 description = "Documentation that simply works"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mkdocs_material-9.5.13-py3-none-any.whl", hash = "sha256:5cbe17fee4e3b4980c8420a04cc762d8dc052ef1e10532abd4fce88e5ea9ce6a"},
-    {file = "mkdocs_material-9.5.13.tar.gz", hash = "sha256:d8e4caae576312a88fd2609b81cf43d233cdbe36860d67a68702b018b425bd87"},
+    {file = "mkdocs_material-9.5.14-py3-none-any.whl", hash = "sha256:a45244ac221fda46ecf8337f00ec0e5cb5348ab9ffb203ca2a0c313b0d4dbc27"},
+    {file = "mkdocs_material-9.5.14.tar.gz", hash = "sha256:2a1f8e67cda2587ab93ecea9ba42d0ca61d1d7b5fad8cf690eeaeb39dcd4b9af"},
 ]
 
 [package.dependencies]
@@ -3085,17 +3085,16 @@ tests = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "textual"
-version = "0.44.1"
+version = "0.53.1"
 description = "Modern Text User Interface framework"
 optional = false
 python-versions = ">=3.8,<4.0"
 files = [
-    {file = "textual-0.44.1-py3-none-any.whl", hash = "sha256:19cfd3a0c623bff02cc80d872ba3e93e1a5b77289fecf74c16ffcfa7407b49a1"},
-    {file = "textual-0.44.1.tar.gz", hash = "sha256:7a45b85943957095b97d0a90c4fa4d3e1028fa26493c0720f403d879157a6589"},
+    {file = "textual-0.53.1-py3-none-any.whl", hash = "sha256:32201aa9d334ed064d5e670f15fe3d7f19c736ca54cecb054a5b995691104434"},
+    {file = "textual-0.53.1.tar.gz", hash = "sha256:23ba673be7974819ded35ea88d28df7117987e53d58f15b2cc890ac2ecf56401"},
 ]
 
 [package.dependencies]
-importlib-metadata = ">=4.11.3"
 markdown-it-py = {version = ">=2.1.0", extras = ["linkify", "plugins"]}
 rich = ">=13.3.3"
 typing-extensions = ">=4.4.0,<5.0.0"
@@ -3343,4 +3342,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "fe9c7211f782fd412db75f348938c888c74913601596f3670afe6a97a26e7896"
+content-hash = "95a6aa9cc65f95b9bd93bda7d39b576d06292839939771f7ff63e4ed26b3ae3d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
+    "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
@@ -32,11 +33,10 @@ packages = [{ include = 'hexabyte' }]
 
 [tool.poetry.dependencies]
 python       = "^3.9"
-textual = "^0.44.1"
+textual = "^0.53.1"
 toml = "^0.10.2"
 munch = "^4.0.0"
 hilbertcurve = "^2.0.5"
-
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.9.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hexabyte"
-version = "0.8.6"
+version = "0.8.7"
 description = "A modern, modular, and robust TUI hex editor."
 keywords = ["commandline", "hexeditor", "binary", "hexadecimal", "raw", "byteview", "bytes"]
 repository = "https://github.com/thetacom/hexabyte"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
 hilbertcurve==2.0.5 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:6a7703d9a2f1fe748c86d86908bf183e7d139b973645e4b2526e10b34e75796d \
     --hash=sha256:dbaad510237d3cd4355c189f00e8dbe66a9e66e03af37f9d3f257799292da363
-importlib-metadata==7.0.2 ; python_version >= "3.9" and python_version < "4.0" \
-    --hash=sha256:198f568f3230878cb1b44fbd7975f87906c22336dba2e4a7f05278c281fbd792 \
-    --hash=sha256:f4bc4c0c070c490abf4ce96d715f68e95923320370efb66143df00199bb6c100
 linkify-it-py==2.0.3 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:68cda27e162e9215c17d786649d1da0021a451bdc436ef9e0fa0ba5234b9b048 \
     --hash=sha256:6bcbc417b0ac14323382aef5c5192c0075bf8a9d6b41820a2b66371eac6b6d79
@@ -65,9 +62,9 @@ pygments==2.17.2 ; python_version >= "3.9" and python_version < "4.0" \
 rich==13.7.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:4edbae314f59eb482f54e9e30bf00d33350aaa94f4bfcd4e9e3110e64d0d7222 \
     --hash=sha256:9be308cb1fe2f1f57d67ce99e95af38a1e2bc71ad9813b0e247cf7ffbcc3a432
-textual==0.44.1 ; python_version >= "3.9" and python_version < "4.0" \
-    --hash=sha256:19cfd3a0c623bff02cc80d872ba3e93e1a5b77289fecf74c16ffcfa7407b49a1 \
-    --hash=sha256:7a45b85943957095b97d0a90c4fa4d3e1028fa26493c0720f403d879157a6589
+textual==0.53.1 ; python_version >= "3.9" and python_version < "4.0" \
+    --hash=sha256:23ba673be7974819ded35ea88d28df7117987e53d58f15b2cc890ac2ecf56401 \
+    --hash=sha256:32201aa9d334ed064d5e670f15fe3d7f19c736ca54cecb054a5b995691104434
 toml==0.10.2 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
     --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
@@ -77,6 +74,3 @@ typing-extensions==4.10.0 ; python_version >= "3.9" and python_version < "4.0" \
 uc-micro-py==1.0.3 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:d321b92cff673ec58027c04015fcaa8bb1e005478643ff4a500882eaab88c48a \
     --hash=sha256:db1dffff340817673d7b466ec86114a9dc0e9d4d9b5ba229d9d60e5c12600cd5
-zipp==3.18.1 ; python_version >= "3.9" and python_version < "4.0" \
-    --hash=sha256:206f5a15f2af3dbaee80769fb7dc6f249695e940acca08dfb2a4769fe61e538b \
-    --hash=sha256:2884ed22e7d8961de1c9a05142eb69a247f120291bc0206a00a7642f09b5b715


### PR DESCRIPTION
- Checks platform when building and rendering InfoPanel. `owner` and `group` only displayed on non-win32 systems.
- Closes #34 